### PR TITLE
add :t alias for :type

### DIFF
--- a/tsun.ts
+++ b/tsun.ts
@@ -458,10 +458,10 @@ function enterPasteMode() {
 function repl(prompt) {
   'use strict';
   rl.question(prompt, function (code) {
-    if (/^:(type|detail)/.test(code)) {
+    if (/^:(type|t|detail)/.test(code)) {
       let identifier = code.split(' ')[1]
       if (!identifier) {
-        console.log(':type|detail command need names!'.red)
+        console.log(':type|t|detail command need names!'.red)
         return repl(prompt)
       }
       getType(identifier, code.indexOf('detail') === 1)


### PR DESCRIPTION
This allows the repl to mimic Prelude like for Haskell and Idris so types can be checked via `:t` as an alias for `:type`.
