### PR TITLE
fix: resolving @types/node if node_modules uses a flat structure

### DIFF
--- a/src/service.ts
+++ b/src/service.ts
@@ -116,7 +116,7 @@ export var getDeclarations = (function() {
 })()
 
 function getDeclarationFiles() {
-  var libPaths = [path.resolve(__dirname, '../../node_modules/@types/node/index.d.ts')]
+  var libPaths = [path.join(path.dirname(require.resolve('@types/node/package.json')), 'index.d.ts')]
   try {
     let typings = path.join(process.cwd(), './typings')
     let dirs = readdirSync(typings)

--- a/src/service.ts
+++ b/src/service.ts
@@ -116,7 +116,7 @@ export var getDeclarations = (function() {
 })()
 
 function getDeclarationFiles() {
-  var libPaths = [path.join(path.dirname(require.resolve('@types/node/package.json')), 'index.d.ts')]
+  var libPaths = [require.resolve('@types/node/index.d.ts')]
   try {
     let typings = path.join(process.cwd(), './typings')
     let dirs = readdirSync(typings)


### PR DESCRIPTION
With more modern node or npm versions, dependencies might get hoisted in the node_modules directory.

Using `require.resolve` this hopefully solves this for newer versions.